### PR TITLE
Fix-up re-rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ os: osx
 osx_image: beta-xcode6.1
 
 env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=34
+    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Au2n7ex5eWNZ637AdneqybUcV58vPSyMR/KEfA7QR7UglXNhsxM1P0gBXc6f6VkjgtEWFVoWUj0GYmYYVe4U0/aYQ5CcpYjqNTp6PNKqzUjK8a7d51aD77f6LQT+h/QHcXAi6PqsDV1fpw7JHDCjC6LFmIVTLfN2yHZw/P6JVWGAqWNRcRB5nbihjpLhpc4mInus13IJR6MU0+U5SXLdl09bjkT2J4zMO3ApZ9vrGy7VwEpA+kgiZFwYURjG78Y9tSxgxdXSvVBwVzMyQahADZJKus+hXEeG5ISIv+5v5OQO0sqLEjHogPhHdyBwHchtUx2jS9af9cRTB2loWFzK8AA1kQuj9YfgxUYrf44zN2Ewt8HidEVRqPtgi28OzsuTmIPXPlhXlH1DKhyL7fgfHPZopgJTfuEiMIgW0X2smtn+pJlyD3dMIB9PxVFK+xWHTHiyfqwFGtcyab6Od1SozRRkJA4YX4rtT2bQOjoaVArXr3d1A8PcG1ymOGNjFGK333sCDRTpWZ7Wc1BaqwQ5vtk++kHL3mr9gy7t3RtcrbgR+sC0I+Rroqceuaz2e3fKno/RM6HlOONbHU0midSoiluT5d70rDQ/66TKIg/bIVR9Bo3Dyybw0MgSZQfh+XOGdDZmAjLGXS3E101kNW6eAsbaCU8MRiTqYWOSCEhbHhg="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,22 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 3 case(s).
+    set -x
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=34
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=35
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,12 @@ requirements:
   build:
     - python
     - setuptools
-    - enum34  # [py<34]
+    - enum34  # [py2k]
     - numpy
     - chemfiles-lib ==0.6.2
   run:
     - python
-    - enum34  # [py<34]
+    - enum34  # [py2k]
     - numpy
     - chemfiles-lib ==0.6.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,7 @@ source:
 build:
   skip: true  # [win]
   number: 0
-  script:
-      - python setup.py install --single-version-externally-managed --record=record.txt
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:


### PR DESCRIPTION
So made a few tweaks as this package wasn't building/deploying correctly. We have some issues in `conda-smithy` with Python version comparison selectors. ( https://github.com/conda-forge/conda-smithy/issues/257 ) However, the `py2k` and `py3k` ones seem to work fine. Switched the selectors here to match and then [re-rendered](https://github.com/conda-forge/conda-smithy#re-rendering-an-existing-feedstock) the feedstock. Please take a look, @Luthaf . If it looks ok, please merge.
