### PR TITLE
Update chemfiles-lib compatibility bounds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [(win and py2k) or (python_impl == 'pypy')]
-  number: 0
+  number: 1
   script: >
     {{ PYTHON }} setup.py install --generator=Ninja --skip-generator-test
 
@@ -26,12 +26,12 @@ requirements:
     - wheel
     - enum34  # [py2k]
     - numpy
-    - chemfiles-lib 0.10.*
+    - chemfiles-lib >=0.10.1,<0.11
   run:
     - python
     - enum34  # [py2k]
     - numpy
-    - chemfiles-lib 0.10.*
+    - chemfiles-lib >=0.10.1,<0.11
 
 test:
   source_files:


### PR DESCRIPTION
We need at least 0.10.1, since a new function was added

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
